### PR TITLE
OSOE-624: ExportTableShouldMatchExpectation fails but only on GitHub-hosted runners in Lombiq.DataTables

### DIFF
--- a/Lombiq.DataTables/Lombiq.DataTables.csproj
+++ b/Lombiq.DataTables/Lombiq.DataTables.csproj
@@ -39,7 +39,6 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.101.0" />
-    <PackageReference Include="itext7" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
     <PackageReference Include="OrchardCore.Contents" Version="1.5.0" />

--- a/Lombiq.DataTables/Lombiq.DataTables.csproj
+++ b/Lombiq.DataTables/Lombiq.DataTables.csproj
@@ -39,6 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.101.0" />
+    <PackageReference Include="itext7" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
     <PackageReference Include="OrchardCore.Contents" Version="1.5.0" />

--- a/Lombiq.DataTables/Lombiq.DataTables.csproj
+++ b/Lombiq.DataTables/Lombiq.DataTables.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.100.3" />
+    <PackageReference Include="ClosedXML" Version="0.101.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
     <PackageReference Include="OrchardCore.Contents" Version="1.5.0" />

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/Lombiq.DataTables.Tests.csproj
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/Lombiq.DataTables.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\..\test\Lombiq.UITestingToolbox\Lombiq.Tests.UI\Lombiq.Tests.UI.csproj" />
     <ProjectReference Include="..\..\Lombiq.DataTables.csproj" />
     <ProjectReference Include="..\..\..\..\..\..\test\Lombiq.Tests\Lombiq.Tests.csproj" />
   </ItemGroup>

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/Lombiq.DataTables.Tests.csproj
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/Lombiq.DataTables.Tests.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\..\test\Lombiq.UITestingToolbox\Lombiq.Tests.UI\Lombiq.Tests.UI.csproj" />
     <ProjectReference Include="..\..\Lombiq.DataTables.csproj" />
     <ProjectReference Include="..\..\..\..\..\..\test\Lombiq.Tests\Lombiq.Tests.csproj" />
   </ItemGroup>

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -33,7 +33,7 @@ public class ExportTests
         {
             _fontProvider.AddSystemFonts();
             // ClosedXML needs a fallback font on all systems but Windows, so let's use the first installed one.
-            var fallbackFont = _fontProvider.GetFontSet().GetFonts().First().GetFontName();
+            var fallbackFont = _fontProvider.GetFontSet().GetFonts().First().GetDescriptor().GetFontName();
 
             // On non-Windows platforms, we need to specify a fallback font manually for ClosedXML to work.
             LoadOptions.DefaultGraphicEngine = new DefaultGraphicEngine(fallbackFont);

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -26,7 +26,7 @@ public class ExportTests
     private static readonly CultureInfo _worksheetCulture = new("en-US", useUserOverride: false);
 
     // ClosedXML needs a fallback font on all systems but Windows, so let's use the first installed one.
-    private static readonly string _fallbackFont = SystemFonts.Collection.Families.ToArray()[3].Name;
+    private static readonly string _fallbackFont = SystemFonts.Collection.Families.ToArray()[1].Name;
 
     public ExportTests()
     {

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -73,15 +73,10 @@ public class ExportTests
 
         Stream stream = null;
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
+        stream = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             // On non-Windows platforms, we need to specify a fallback font manually for ClosedXML to work.
-            stream = await service.ExportAsync(provider, request, customNumberFormat: customNumberFormat);
-        }
-        else
-        {
-            stream = await TryExportWithFallbackFontsAsync(service, provider, request, customNumberFormat);
-        }
+            ? await service.ExportAsync(provider, request, customNumberFormat: customNumberFormat)
+            : await TryExportWithFallbackFontsAsync(service, provider, request, customNumberFormat);
 
         using var workbook = new XLWorkbook(stream);
         var worksheet = workbook.Worksheets.Worksheet(1);

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -1,6 +1,5 @@
 using ClosedXML.Excel;
 using ClosedXML.Graphics;
-using iText.Layout.Font;
 using Lombiq.DataTables.Models;
 using Lombiq.DataTables.Services;
 using Lombiq.DataTables.Tests.Helpers;
@@ -9,6 +8,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Moq.AutoMock;
 using Shouldly;
+using SixLabors.Fonts;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -22,21 +22,18 @@ namespace Lombiq.DataTables.Tests.UnitTests.Services;
 
 public class ExportTests
 {
-    private static readonly FontProvider _fontProvider = new();
-
     // ClosedXML looks at the CurrentCulture to initialize the workbook's culture.
     private static readonly CultureInfo _worksheetCulture = new("en-US", useUserOverride: false);
+
+    // ClosedXML needs a fallback font on all systems but Windows, so let's use the first installed one.
+    private static readonly string _fallbackFont = SystemFonts.Collection.Families.ToArray()[3].Name;
 
     public ExportTests()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            _fontProvider.AddSystemFonts();
-            // ClosedXML needs a fallback font on all systems but Windows, so let's use the first installed one.
-            var fallbackFont = _fontProvider.GetFontSet().GetFonts().First().GetDescriptor().GetFontName();
-
             // On non-Windows platforms, we need to specify a fallback font manually for ClosedXML to work.
-            LoadOptions.DefaultGraphicEngine = new DefaultGraphicEngine(fallbackFont);
+            LoadOptions.DefaultGraphicEngine = new DefaultGraphicEngine(_fallbackFont);
         }
     }
 

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -242,7 +242,7 @@ public class ExportTests
         };
     }
 
-    // Sometimes a font is available however, it's corrupted or missing a table (for example, this can happen on
+    // Sometimes a font is available, however, it's corrupted or missing a table (for example, this can happen on
     // GitHub-hosted runners). We can't check directly if a font is missing a table or corrupted, but we can try
     // other fonts if this happens.
     private static async Task<Stream> TryExportWithFallbackFontsAsync(

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -24,7 +24,6 @@ public class ExportTests
 {
     private static readonly FontProvider _fontProvider = new();
 
-
     // ClosedXML looks at the CurrentCulture to initialize the workbook's culture.
     private static readonly CultureInfo _worksheetCulture = new("en-US", useUserOverride: false);
 

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -1,5 +1,6 @@
 using ClosedXML.Excel;
 using ClosedXML.Graphics;
+using iText.Layout.Font;
 using Lombiq.DataTables.Models;
 using Lombiq.DataTables.Services;
 using Lombiq.DataTables.Tests.Helpers;
@@ -21,8 +22,8 @@ namespace Lombiq.DataTables.Tests.UnitTests.Services;
 
 public class ExportTests
 {
-    // ClosedXML needs a fallback font on all systems but Windows, so let's use the first installed one.
-    private const string _fallbackFont = "this is just debugging";
+    private static readonly FontProvider _fontProvider = new();
+
 
     // ClosedXML looks at the CurrentCulture to initialize the workbook's culture.
     private static readonly CultureInfo _worksheetCulture = new("en-US", useUserOverride: false);
@@ -31,8 +32,12 @@ public class ExportTests
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
+            _fontProvider.AddSystemFonts();
+            // ClosedXML needs a fallback font on all systems but Windows, so let's use the first installed one.
+            var fallbackFont = _fontProvider.GetFontSet().GetFonts().First().GetFontName();
+
             // On non-Windows platforms, we need to specify a fallback font manually for ClosedXML to work.
-            LoadOptions.DefaultGraphicEngine = new DefaultGraphicEngine(_fallbackFont);
+            LoadOptions.DefaultGraphicEngine = new DefaultGraphicEngine(fallbackFont);
         }
     }
 

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -26,7 +26,7 @@ public class ExportTests
     private static readonly CultureInfo _worksheetCulture = new("en-US", useUserOverride: false);
 
     // ClosedXML needs a fallback font on all systems but Windows, so let's use the first installed one.
-    private static readonly string _fallbackFont = SystemFonts.Collection.Families.First().Name;
+    private static readonly string _fallbackFont = "this is just debugging";
 
     public ExportTests()
     {

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -30,6 +30,11 @@ public class ExportTests
 
     public ExportTests()
     {
+        foreach (var font in SystemFonts.Collection.Families)
+        {
+            Console.WriteLine(font.Name);
+        }
+
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             // On non-Windows platforms, we need to specify a fallback font manually for ClosedXML to work.

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -258,8 +258,7 @@ public class ExportTests
     {
         var fontFamilies = SystemFonts.Collection.Families.ToArray();
 
-        var fontFamiliesLength = fontFamilies.Length;
-        var maxAttempts = Math.Min(3, fontFamiliesLength);
+        var maxAttempts = Math.Min(3, fontFamilies.Length);
         var fontIndex = 0;
 
         while (fontIndex < maxAttempts)

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -4,7 +4,6 @@ using Lombiq.DataTables.Models;
 using Lombiq.DataTables.Services;
 using Lombiq.DataTables.Tests.Helpers;
 using Lombiq.Tests.Helpers;
-using Lombiq.Tests.UI.Helpers;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Moq.AutoMock;

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -268,9 +268,9 @@ public class ExportTests
             }
             catch (MissingFontTableException missingFontTableException)
             {
-                DebugHelper.WriteLineTimestamped($"Attempt {(fontIndex + 1).ToTechnicalString()} of exporting the" +
-                    $" data table with the font {fallbackFont} failed with the MissingFontTableException: " +
-                    $"{missingFontTableException.Message}.");
+                DebugHelper.WriteLineTimestamped(
+                    $"Attempt {(fontIndex + 1).ToTechnicalString()} of exporting the data table with the font " +
+                    $"{fallbackFont} failed with the MissingFontTableException: {missingFontTableException.Message}.");
 
                 if (fontIndex + 1 < maxAttempts)
                 {

--- a/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
+++ b/Lombiq.DataTables/Tests/Lombiq.DataTables.Tests/UnitTests/Services/ExportTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Moq.AutoMock;
 using Shouldly;
-using SixLabors.Fonts;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -22,11 +21,11 @@ namespace Lombiq.DataTables.Tests.UnitTests.Services;
 
 public class ExportTests
 {
+    // ClosedXML needs a fallback font on all systems but Windows, so let's use the first installed one.
+    private const string _fallbackFont = "this is just debugging";
+
     // ClosedXML looks at the CurrentCulture to initialize the workbook's culture.
     private static readonly CultureInfo _worksheetCulture = new("en-US", useUserOverride: false);
-
-    // ClosedXML needs a fallback font on all systems but Windows, so let's use the first installed one.
-    private static readonly string _fallbackFont = "this is just debugging";
 
     public ExportTests()
     {


### PR DESCRIPTION
[OSOE-624](https://lombiq.atlassian.net/browse/OSOE-624)
Fixes #138 

[OSOE-624]: https://lombiq.atlassian.net/browse/OSOE-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ