### PR TITLE
OSOE-1263: Update dependencies and fix IDE0004 in ExportDate

### DIFF
--- a/Lombiq.DataTables.Tests/Lombiq.DataTables.Tests.csproj
+++ b/Lombiq.DataTables.Tests/Lombiq.DataTables.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="OrchardCore.Liquid" Version="2.1.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Lombiq.DataTables/Models/ExportDate.cs
+++ b/Lombiq.DataTables/Models/ExportDate.cs
@@ -50,8 +50,8 @@ public class ExportDate
         new LocalDate(exportDate.Year, exportDate.Month, exportDate.Day).ToDateTimeUnspecified();
 
     public static implicit operator ExportDate(LocalDate? localDateNullable) =>
-        localDateNullable is { } localDate ? localDate : (ExportDate)null;
+        localDateNullable is { } localDate ? localDate : null;
 
     public static implicit operator ExportDate(DateTime? dateTimeNullable) =>
-        dateTimeNullable is { } dateTime ? dateTime : (ExportDate)null;
+        dateTimeNullable is { } dateTime ? dateTime : null;
 }


### PR DESCRIPTION
## Summary
- update dependency Microsoft.NET.Test.Sdk to 18.4.0
- fix IDE0004 redundant cast warnings in ExportDate

## Issue
- [OSOE-1263](https://lombiq.atlassian.net/browse/OSOE-1263)

[OSOE-1263]: https://lombiq.atlassian.net/browse/OSOE-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ